### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -14,6 +14,9 @@ on:
       - "**/*.bash"
       - ".github/workflows/shellcheck.yml"
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Seika139/dotfiles/security/code-scanning/1](https://github.com/Seika139/dotfiles/security/code-scanning/1)

To fix the problem, explicitly declare limited `GITHUB_TOKEN` permissions for this workflow or for the `shellcheck` job. Since the workflow only needs to read the repository contents (via `actions/checkout`) and then runs tools locally, the least-privilege configuration is to set `contents: read`. This can be done at the workflow root so it applies to all jobs.

Concretely, in `.github/workflows/shellcheck.yml`, add a top-level `permissions:` block after the `on:` section and before `jobs:`. Set `contents: read` as recommended by CodeQL. No other permissions appear necessary from the snippet provided, and no imports or additional code are required because this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub Actionsワークフローの権限設定を更新しました。

---

**注**: このリリースはエンドユーザーに直接影響する変更は含まれていません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->