### PR TITLE
chore: release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Tagged Releases
 
-- [unreleased](https://github.com/Seika139/dotfiles/compare/v0.5.0...HEAD)
+- [unreleased](https://github.com/Seika139/dotfiles/compare/v0.5.1...HEAD)
+- [0.5.1](https://github.com/Seika139/dotfiles/compare/v0.5.0...v0.5.1)
 - [0.5.0](https://github.com/Seika139/dotfiles/compare/v0.4.0...v0.5.0)
 - [0.4.0](https://github.com/Seika139/dotfiles/compare/v0.3.2...v0.4.0)
 - [0.3.2](https://github.com/Seika139/dotfiles/compare/v0.3.1...v0.3.2)
@@ -17,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [0.1.0](https://github.com/Seika139/dotfiles/tree/v0.1.0)
 
 ## [Unreleased]
+
+## [0.5.1] - 2026-02-03
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # dotfiles
 
 <div align="center">
-  <a href="https://github.com/Seika139/dotfiles/releases/tag/v0.5.0">
-    <img alt="version" src="https://img.shields.io/badge/version-v0.5.0-white.svg">
+  <a href="https://github.com/Seika139/dotfiles/releases/tag/v0.5.1">
+    <img alt="version" src="https://img.shields.io/badge/version-v0.5.1-white.svg">
   </a>
   &nbsp;&nbsp;
   <a href="https://github.com/Seika139/dotfiles/actions/workflows/lint-markdown.yml">


### PR DESCRIPTION
## 概要
- Release version: 0.5.1
- Tag: v0.5.1
- Branch: release/v0.5.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **チョア（メンテナンス）**
  * バージョン情報が v0.5.0 から v0.5.1 に更新されました
  * CHANGELOG に新しいバージョン 0.5.1 のエントリが追加されました
  * README のバージョンバッジと参照リンクがアップデートされました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->